### PR TITLE
Change log4j version of the jar and add dependencies on codec-plain fixe...

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -6,7 +6,7 @@ require "logstash/namespace"
 require "logstash/util/socket_peer"
 require "socket"
 require "timeout"
-require 'logstash-input-log4j_jars.rb'
+require 'logstash-input-log4j_jars'
 
 # Read events over a TCP socket from a Log4j SocketAppender.
 #

--- a/logstash-input-log4j.gemspec
+++ b/logstash-input-log4j.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "group" => "input" }
 
   # Jar dependencies
-  s.requirements << "jar 'org.apache.logging.log4j:log4j', '2.0.2'"
+  s.requirements << "jar 'log4j:log4j', '1.2.17'"
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'jar-dependencies', ['~> 0.0.6']
-
 end
 


### PR DESCRIPTION
Before splitting into multiples plugins the log4j input plugin was using the version bundled with elasticsearch.
- I've change the declared version from 2.0.2 to 1.2.17. (same version as before)
- Added a dependencies on codec-plain.

fixes #1 
