### PR TITLE
Add a missing dependency so test are happy again. 

### DIFF
--- a/logstash-input-log4j.gemspec
+++ b/logstash-input-log4j.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jar-dependencies', '0.1.7'
   s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
   s.add_runtime_dependency "maven-tools", '1.0.7'
+  s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Added a missing dependency to test are up and running again and obviously, minimal, but happy and green.

We should however, as the codec=> plain is the default one

From: https://github.com/elastic/logstash/blob/master/lib/logstash/inputs/base.rb#L33
```
  # The codec used for input data. Input codecs are a convenient method for decoding your data before it enters the input, without needing a separate filter in your Logstash pipeline.
  config :codec, :validate => :codec, :default => "plain"
```

move this dependency to the main logstash-core :+1: 

- purbon