### PR TITLE
remove ROOT_DIR constant from jars loading file

### DIFF
--- a/lib/logstash-input-log4j_jars.rb
+++ b/lib/logstash-input-log4j_jars.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 require 'logstash/environment'
 
-ROOT_DIR   = File.expand_path(File.join(File.dirname(__FILE__), ".."))
-LogStash::Environment.load_runtime_jars! File.join(ROOT_DIR, "vendor")
+root_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+LogStash::Environment.load_runtime_jars! File.join(root_dir, "vendor")


### PR DESCRIPTION
since this code is present on all plugins that contain jars, each one
will define ROOT_DIR, causing warnings