### PR TITLE
Capture LoggingEvent original timestamp + document Event Schema

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -63,6 +63,7 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
   def create_event(log4j_obj)
     # NOTE: log4j_obj is org.apache.log4j.spi.LoggingEvent
     event = LogStash::Event.new("message" => log4j_obj.getRenderedMessage)
+    event["timestamp"] = log4j_obj.getTimeStamp
     event["path"] = log4j_obj.getLoggerName
     event["priority"] = log4j_obj.getLevel.toString
     event["logger_name"] = log4j_obj.getLoggerName

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -14,6 +14,21 @@ require 'logstash-input-log4j_jars'
 # depending on `mode`. Depending on which `mode` is configured,
 # you need a matching SocketAppender or a SocketHubAppender
 # on the remote side.
+#
+# One event is created per received log4j LoggingEvent with the following schema:
+#
+# * `timestamp` => the number of milliseconds elapsed from 1/1/1970 until logging event was created.
+# * `path` => the name of the logger
+# * `priority` => the level of this event
+# * `logger_name` => the name of the logger
+# * `thread` => the thread name making the logging request
+# * `class` => the fully qualified class name of the caller making the logging request.
+# * `file` => the source file name and line number of the caller making the logging request in a colon-separated format "fileName:lineNumber".
+# * `method` => the method name of the caller making the logging request.
+# * `NDC` => the NDC string
+# * `stack_trace` => the multi-line stack-trace
+#
+# Also if the original log4j LoggingEvent contains MDC hash entries, they will be merged in the event as fields.
 class LogStash::Inputs::Log4j < LogStash::Inputs::Base
 
   config_name "log4j"

--- a/spec/inputs/log4j_spec.rb
+++ b/spec/inputs/log4j_spec.rb
@@ -37,6 +37,7 @@ describe "inputs/log4j" do
 
     it "creates event with general information" do
       subject = input.create_event(log_obj)
+      expect(subject["timestamp"]).to eq(1426366971)
       expect(subject["path"]).to eq("org.apache.log4j.LayoutTest")
       expect(subject["priority"]).to eq("INFO")
       expect(subject["logger_name"]).to eq("org.apache.log4j.LayoutTest")


### PR DESCRIPTION
Collect the original timestamp without altering its format (milliseconds in a long), leaving the @timestamp setting/formatting to the date filter. This could cover the use case described in https://github.com/elastic/logstash/pull/995

Also I tried to describe in simple asciidoc the event schema that is produced by this input.
It would be great if you could provide a more advanced template on how to document "structured-inputs".