### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/spec/inputs/log4j_spec.rb
+++ b/spec/inputs/log4j_spec.rb
@@ -1,14 +1,26 @@
 # encoding: utf-8
-
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/log4j"
 require "logstash/plugin"
 
-describe "inputs/log4j" do
+describe LogStash::Inputs::Log4j do
 
   it "should register" do
     input = LogStash::Plugin.lookup("input", "log4j").new("mode" => "client")
 
     # register will try to load jars and raise if it cannot find jars or if org.apache.log4j.spi.LoggingEvent class is not present
     expect {input.register}.to_not raise_error
+  end
+
+  context "when interrupting the plugin" do
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "mode" =>  "server" } }
+    end
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "mode" =>  "client" } }
+    end
   end
 
   context "reading general information from a org.apache.log4j.spi.LoggingEvent" do


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812