### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -126,7 +126,6 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
   # method used to stop the plugin and unblock
   # pending blocking operatings like sockets and others.
   def stop
-    super
     @server_socket.close if @server_socket && !@server_socket.closed?
   end
 


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #19 