### PR TITLE
Fix failing when using `abort_on_exception` and running the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Fix tests with `Thread.abort_on_exception` turn on
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -142,7 +142,10 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
   # method used to stop the plugin and unblock
   # pending blocking operatings like sockets and others.
   def stop
-    @server_socket.close if @server_socket && !@server_socket.closed?
+    begin
+      @server_socket.close if @server_socket && !@server_socket.closed?
+    rescue IOError
+    end
   end
 
   public
@@ -164,5 +167,6 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
         handle_socket(client_socket, output_queue)
       end # loop
     end
+  rescue IOError
   end # def run
 end # class LogStash::Inputs::Log4j

--- a/logstash-input-log4j.gemspec
+++ b/logstash-input-log4j.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-log4j'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a TCP socket from a Log4j SocketAppender"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/log4j_spec.rb
+++ b/spec/inputs/log4j_spec.rb
@@ -3,7 +3,6 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/log4j"
 require "logstash/plugin"
 
-Thread.abort_on_exception = true
 describe LogStash::Inputs::Log4j do
 
   it "should register" do


### PR DESCRIPTION
Fix failing when using `abort_on_exception` and running the tests inside the logstash project.