### PR TITLE
Make tests not depend on exact thread name of 'main' thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+ - Fix a spec that was incompatible with the ng pipeline
+## 2.0.4
+ - Bump for LS 2.x compatibility
 ## 2.0.3
  - Refactor code to improve test reliability
 ## 2.0.2

--- a/logstash-input-log4j.gemspec
+++ b/logstash-input-log4j.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-log4j'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a TCP socket from a Log4j SocketAppender"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/log4j_spec.rb
+++ b/spec/inputs/log4j_spec.rb
@@ -64,7 +64,8 @@ describe LogStash::Inputs::Log4j do
       expect(subject["path"]).to eq("org.apache.log4j.LayoutTest")
       expect(subject["priority"]).to eq("INFO")
       expect(subject["logger_name"]).to eq("org.apache.log4j.LayoutTest")
-      expect(subject["thread"]).to eq("main")
+      expect(subject["thread"]).to be_a(String)
+      expect(subject["thread"]).not_to be_empty
       expect(subject["message"]).to eq("Hello, World")
       # checks locationInformation is collected, but testing exact values is not meaningful in jruby
       expect(subject["class"]).not_to be_empty


### PR DESCRIPTION
This is important because the thread name could be something other than
main.
So long as it is a string that's close enough

Fixes #27 