### PR TITLE
mark `data_timeout` as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,33 @@
+## 3.0.3
+  - `data_timeout` is now marked as obsolete, since this option is no longer necessary
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 
 ## 3.0.1
   - Republish all the gems under jruby.
+
 ## 3.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+
 # 2.0.7
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
+
 # 2.0.6
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.5
  - Fix a spec that was incompatible with the ng pipeline
+
 ## 2.0.4
  - Bump for LS 2.x compatibility
+
 ## 2.0.3
  - Refactor code to improve test reliability
+
 ## 2.0.2
  - Fix tests with `Thread.abort_on_exception` turn on
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -44,8 +44,8 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
   # Read timeout in seconds. If a particular TCP connection is
   # idle for more than this timeout period, we will assume
   # it is dead and close it.
-  # If you never want to timeout, use -1.
-  config :data_timeout, :validate => :number, :default => 5
+  # If you never want to timeout, use -1.,
+  config :data_timeout, :validate => :number, :default => 5, :obsolete => "This option no longer necessary, the input will now keep the connection open."
 
   # Mode to operate in. `server` listens for client connections,
   # `client` connects to a server.

--- a/logstash-input-log4j.gemspec
+++ b/logstash-input-log4j.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-log4j'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a TCP socket from a Log4j SocketAppender"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The `data_timeout` setting is now longer use anywhere in the code base it' time to mark it as obsolete. This will make the option no longer appear in the documentation and logstash will refuse to start if its used.