### PR TITLE
Add instructions for migrating away from log4j

### DIFF
--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -133,12 +133,13 @@ class LogStash::Inputs::Log4j < LogStash::Inputs::Base
 
   public
   def register
-
     begin
       Java::OrgApacheLog4jSpi.const_get("LoggingEvent")
     rescue
       raise(LogStash::PluginLoadingError, "Log4j java library not loaded")
     end
+
+    @logger.warn("This plugin is deprecated. Please use filebeat instead to collect logs from log4j applications.")
 
     if server?
       @logger.info("Starting Log4j input listener", :address => "#{@host}:#{@port}")

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -8,6 +8,9 @@ require "socket"
 require "timeout"
 require 'logstash-input-log4j_jars'
 
+# DEPRECATION NOTICE
+# ==================
+#
 # NOTE: This plugin is deprecated. It is recommended that you use filebeat to collect logs from log4j.
 #
 # The following section is a guide for how to migrate from SocketAppender to use filebeat.
@@ -18,52 +21,62 @@ require 'logstash-input-log4j_jars'
 # 2) Install and configure filebeat to collect those logs and ship them to Logstash
 # 3) Configure Logstash to use the beats input.
 #
-#
 # Configuring log4j for writing to local files
 # --------------------------------------------
 # 
-# In your log4j.properties file, where you have SocketAppender, remove SocketAppender and replace it with RollingFileAppender. 
+# In your log4j.properties file, remove SocketAppender and replace it with RollingFileAppender. 
 #
-# For example, you can use this log4j.properties configuration to keep 7 days of logs on disk:
+# For example, you can use the following log4j.properties configuration to write daily log files.
 #
-# # Your app's log4j.properties (log4j 1.2 only)
-# log4j.rootLogger=daily
-# log4j.appender.daily=org.apache.log4j.rolling.RollingFileAppender
-# log4j.appender.daily.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
-# log4j.appender.daily.RollingPolicy.FileNamePattern=/var/log/your-app/app.%d.log
-# log4j.appender.daily.layout = org.apache.log4j.PatternLayout
-# log4j.appender.daily.layout.ConversionPattern=%d{YYYY-MM-dd HH:mm:ss,SSSZ} %p %c{1}:%L - %m%n
+#     # Your app's log4j.properties (log4j 1.2 only)
+#     log4j.rootLogger=daily
+#     log4j.appender.daily=org.apache.log4j.rolling.RollingFileAppender
+#     log4j.appender.daily.RollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+#     log4j.appender.daily.RollingPolicy.FileNamePattern=/var/log/your-app/app.%d.log
+#     log4j.appender.daily.layout = org.apache.log4j.PatternLayout
+#     log4j.appender.daily.layout.ConversionPattern=%d{YYYY-MM-dd HH:mm:ss,SSSZ} %p %c{1}:%L - %m%n
 #
+# Configuring log4j.properties in more detail is outside the scope of this migration guide.
 #
 # Configuring filebeat
 # --------------------
 #
-# Next, install and configure filebeat to collect these logs:
+# Next,
+# https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
+# filebeat]. Based on the above log4j.properties, we can use this filebeat
+# configuration:
 #
-# # filebeat.yml
-# filebeat:
-#   prospectors:
-#     -
-#       paths:
-#         - /var/log/your-app/app.*.log
-#       input_type: log
-# output:
-#   logstash:
-#     hosts: ["your-logstash-host:5000"]
+#     # filebeat.yml
+#     filebeat:
+#       prospectors:
+#         -
+#           paths:
+#             - /var/log/your-app/app.*.log
+#           input_type: log
+#     output:
+#       logstash:
+#         hosts: ["your-logstash-host:5000"]
+#
+# For more details on configuring filebeat, see 
+# https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
 #
 # Configuring Logstash to receive from filebeat
 # ---------------------------------------------
 #
 # Finally, configure Logstash with a beats input:
 #
-# # logstash configuration
-# input {
-#   beats {
-#     port => 5000
-#   }
-# }
+#     # logstash configuration
+#     input {
+#       beats {
+#         port => 5000
+#       }
+#     }
 #
-# It is strongly recommended that you also configure filebeat and logstash beats input to use TLS.
+# It is strongly recommended that you also enable TLS in filebeat and logstash
+# beats input for protection and safety of your log data..
+#
+# For more details on configuring the beats input, see
+# https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
 
 # ----
 #

--- a/lib/logstash/inputs/log4j.rb
+++ b/lib/logstash/inputs/log4j.rb
@@ -8,8 +8,7 @@ require "socket"
 require "timeout"
 require 'logstash-input-log4j_jars'
 
-# DEPRECATION NOTICE
-# ==================
+# ==== Deprecation Notice
 #
 # NOTE: This plugin is deprecated. It is recommended that you use filebeat to collect logs from log4j.
 #
@@ -21,8 +20,7 @@ require 'logstash-input-log4j_jars'
 # 2) Install and configure filebeat to collect those logs and ship them to Logstash
 # 3) Configure Logstash to use the beats input.
 #
-# Configuring log4j for writing to local files
-# --------------------------------------------
+# .Configuring log4j for writing to local files
 # 
 # In your log4j.properties file, remove SocketAppender and replace it with RollingFileAppender. 
 #
@@ -38,8 +36,7 @@ require 'logstash-input-log4j_jars'
 #
 # Configuring log4j.properties in more detail is outside the scope of this migration guide.
 #
-# Configuring filebeat
-# --------------------
+# .Configuring filebeat
 #
 # Next,
 # https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html[install
@@ -60,8 +57,7 @@ require 'logstash-input-log4j_jars'
 # For more details on configuring filebeat, see 
 # https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration.html[the filebeat configuration guide].
 #
-# Configuring Logstash to receive from filebeat
-# ---------------------------------------------
+# .Configuring Logstash to receive from filebeat
 #
 # Finally, configure Logstash with a beats input:
 #
@@ -77,8 +73,8 @@ require 'logstash-input-log4j_jars'
 #
 # For more details on configuring the beats input, see
 # https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[the logstash beats input documentation].
-
-# ----
+#
+# '''
 #
 # Read events over a TCP socket from a Log4j SocketAppender. This plugin works only with log4j version 1.x.
 #


### PR DESCRIPTION
Target is for moving from SocketAppender to using filebeat for secure,
asynchronous, and reliable log transport.